### PR TITLE
Execute dispatcher with Flask application context

### DIFF
--- a/flask_spyne/flask_spyne.py
+++ b/flask_spyne/flask_spyne.py
@@ -32,11 +32,11 @@ class InvalidCredentialsError(Fault):
 class SpyneController(object):
     def __init__(self, app=None):
         self.services = {}
-        self.app = app
         if app:
             self.init_app(app)
 
     def init_app(self, app):
+        self.app = app
         self.real_wsgi_app = app.wsgi_app
         app.wsgi_app = self.wsgi_app
 
@@ -55,7 +55,8 @@ class SpyneController(object):
         
     def wsgi_app(self, environ, start_response):
         dispatcher = DispatcherMiddleware(self.real_wsgi_app, self.services)
-        return dispatcher(environ, start_response)
+        with self.app.app_context():
+            return dispatcher(environ, start_response)
 
 class SpyneService(ServiceBase):
     __target_namespace__ = 'tns'

--- a/flask_spyne/flask_spyne.py
+++ b/flask_spyne/flask_spyne.py
@@ -14,7 +14,7 @@ from spyne.application import Application
 from spyne.decorator import rpc, srpc
 from spyne.service import ServiceBase, ServiceBaseMeta
 from spyne.server.wsgi import WsgiApplication
-from flask import current_app
+from flask import _app_ctx_stack
 
 from secwall import wsse
 from secwall.core import SecurityException
@@ -51,52 +51,53 @@ class SpyneController(object):
             name=service.__name__,
             in_protocol=service.__in_protocol__,
             out_protocol=service.__out_protocol__)
+        spyne_app.event_manager.add_listener('method_call',
+                                             self._on_method_call)
+        spyne_app.event_manager.add_listener('method_return_object',
+                                             self._on_method_return_object)
         wsgi_app = WsgiApplication(spyne_app)
         self.services[service.__service_url_path__] = wsgi_app
-        
+
     def wsgi_app(self, environ, start_response):
         dispatcher = DispatcherMiddleware(self.real_wsgi_app, self.services)
-        ctx = None
-        if not current_app:
-            ctx = self.app.app_context().push()
-        try:
-            return dispatcher(environ, start_response)
-        finally:
-            if ctx:
-                ctx.pop()
+        return dispatcher(environ, start_response)
+
+    def _on_method_call(self, ctx):
+        if not _app_ctx_stack.top:
+            appctx = self.app.app_context()
+            ctx.udc = {"_spyne_ctx": appctx}
+            appctx.push()
+        logging.debug('request: {0}'.format(ctx.in_object))
+        if ctx.service_class.__in_protocol__.__class__.__name__ == 'Soap11':
+            logging.debug('request: {0}'.format(etree.tostring(ctx.in_document, pretty_print=True)))
+            if hasattr(ctx.service_class, '__wsse_conf__'):
+                def_conf = {
+                    'reject-empty-nonce-creation': False,
+                }
+                wsse_conf = dict(def_conf.items() + ctx.service_class.__wsse_conf__.items())
+                for k, v in wsse_conf.items():
+                    wsse_conf['wsse-pwd-{0}'.format(k)] = v
+                try:
+                    FSWSSE().validate(ctx.in_document, wsse_conf)
+                except SecurityException as e:
+                    logging.exception(e)
+                    raise InvalidCredentialsError(e.description)
+
+    def _on_method_return_object(self, ctx):
+        logging.debug('response: {0}'.format(ctx.out_object))
+        appctx = ctx.udc and ctx.udc.get("_spyne_ctx")
+        if appctx:
+            appctx.pop()
 
 
 class SpyneService(ServiceBase):
     __target_namespace__ = 'tns'
     __service_url_path__ = '/rpc'
-    
+
+
 class FSWSSE(wsse.WSSE):
     def check_nonce(self, wsse_nonce, now, nonce_freshness_time):
         pass # TODO
-
-def _on_method_call(ctx):
-    logging.debug('request: {0}'.format(ctx.in_object))
-    if ctx.service_class.__in_protocol__.__class__.__name__ == 'Soap11':
-        logging.debug('request: {0}'.format(etree.tostring(ctx.in_document, pretty_print=True)))
-        if hasattr(ctx.service_class, '__wsse_conf__'):
-            def_conf = {
-                'reject-empty-nonce-creation': False,
-            }
-            wsse_conf = dict(def_conf.items() + ctx.service_class.__wsse_conf__.items())
-            for k, v in wsse_conf.items():
-                wsse_conf['wsse-pwd-{0}'.format(k)] = v
-            try:               
-                auth_res = FSWSSE().validate(ctx.in_document, wsse_conf) 
-            except SecurityException as e:
-                logging.exception(e)
-                raise InvalidCredentialsError(e.description)
-    return
-
-def _on_method_return_object(ctx):
-    logging.debug('response: {0}'.format(ctx.out_object))
-
-SpyneService.event_manager.add_listener('method_call', _on_method_call)
-SpyneService.event_manager.add_listener('method_return_object', _on_method_return_object)
 
 
 class Spyne(object):


### PR DESCRIPTION
This change provide a Flask application context in my Spyne service (`current_user`, `current_app`, Flask-SQLAlchemy `db`, config dict...). It is a really useful improvement.

It is a bit controversial to me. The `init_app` must not bind the app to the extension, but it already indirectly happens with `real_wsgi_app`, so it is not a real issue. The access to application context adds a lot of value to this extension.
