### PR TITLE
Update werkzeug class for dispatcher middleware

### DIFF
--- a/flask_spyne/flask_spyne.py
+++ b/flask_spyne/flask_spyne.py
@@ -1,6 +1,6 @@
 import logging
 
-from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from spyne.application import Application
 from spyne.decorator import rpc, srpc


### PR DESCRIPTION
werkzeug has been depricated, werkzeug.middleware.dispatcher is seemingly needed instead of werkzeug.wsgi